### PR TITLE
refactor: flatten nested if-else blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,8 @@ export default function workerize(code) {
 					return;
 				}
 
-				Promise.resolve(method.apply(null, data.params))
+				Promise.resolve()
+					.then( method.apply(null, data.params) )
 					.then( result => { ctx.postMessage({ type: 'RPC', id, result }); })
 					.catch( error => { ctx.postMessage({ type: 'RPC', id, error }); });
 				return;

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default function workerize(code) {
 					return;
 				}
 
-				Promise.resolve(() => method.apply(null, data.params))
+				Promise.resolve(method.apply(null, data.params))
 					.then( result => { ctx.postMessage({ type: 'RPC', id, result }); })
 					.catch( error => { ctx.postMessage({ type: 'RPC', id, error }); });
 				return;

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,7 @@ export default function workerize(code) {
 					return;
 				}
 
-				Promise.resolve()
-					.then( () => method.apply(null, data.params) )
+				Promise.resolve(() => method.apply(null, data.params))
 					.then( result => { ctx.postMessage({ type: 'RPC', id, result }); })
 					.catch( error => { ctx.postMessage({ type: 'RPC', id, error }); });
 				return;

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export default function workerize(code) {
 				}
 
 				Promise.resolve()
-					.then( method.apply(null, data.params) )
+					.then( () => method.apply(null, data.params) )
 					.then( result => { ctx.postMessage({ type: 'RPC', id, result }); })
 					.catch( error => { ctx.postMessage({ type: 'RPC', id, error }); });
 				return;


### PR DESCRIPTION
apply "return early, avoid else" practice to make code simple and easy to read