### PR TITLE
Pass worker as context, `this` not set inside arrow fn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default function workerize(code, options) {
 	};
 	worker.terminate = () => {
 		URL.revokeObjectURL(url);
-		term.call(this);
+		term.call(worker);
 	};
 	worker.call = (method, params) => new Promise( (resolve, reject) => {
 		let id = `rpc${++counter}`;


### PR DESCRIPTION
`this` is undefined because `worker.terminate` is an arrow function. Instead, we can just pass `worker` in explicitly.